### PR TITLE
feat: add a href to paladin.opendoor.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Paladin is setup to use within an Umbrella application.
 
 #### Setup your services
 
-1. Register you application with Paladin
-2. Register a second application with Paladin.
+1. Register your application with [Paladin](https://paladin.opendoor.com/) (use your [www.opendoor.com](https://www.opendoor.com/) login credentials)
+2. Register a second application with [Paladin](https://paladin.opendoor.com/).
 3. Configure a connection from one to another (including max permissions and TTL)
 
 #### Regular requests


### PR DESCRIPTION
While adding authentication via Paladin to a new service, I had to trace a few docs to find information about what it meant to "Register your application with Paladin", so I've added it here!

@hassox 